### PR TITLE
Update FacebookLoginButtonRenderer.cs

### DIFF
--- a/iOS/Renderers/FacebookLoginButtonRenderer.cs
+++ b/iOS/Renderers/FacebookLoginButtonRenderer.cs
@@ -14,7 +14,7 @@ namespace XFFacebookExample.iOS
         protected override void OnElementChanged(ElementChangedEventArgs<View> e)
         {
             base.OnElementChanged(e);
-            if (Control == null)
+            if (Control == null && e.NewElement != null)
             {
                 var fbLoginBtnView = e.NewElement as FacebookLoginButton;
                 var fbLoginbBtnCtrl = new LoginButton


### PR DESCRIPTION
When the view that have the Facebook login button displayed are poped and transitioned into another view before the button have been disposed it's going to call the OnElementChanged after the UI have left the previous view which will make the "NewElement" property to become null. Adding a null condition to it resolves the issue and does not have any other impact on the overall functionality of the renderer.